### PR TITLE
[Sprint-2] Widget Tree & Reactive UI – Asgradians

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,38 @@ lib/
 Connecting Flutter with Firebase was initially challenging due to platform configuration issues. After proper setup, authentication and database features worked smoothly. Firebase enables secure login, real-time updates, and makes the application scalable for future growth.
 
 ---
+
+
+## Understanding Widget Tree & Reactive UI (Sprint #2)
+
+### 📌 Description
+This task demonstrates Flutter’s widget tree structure and its reactive UI model. A simple demo screen was created to show how widgets are arranged in a hierarchy and how the UI updates automatically when the state changes.
+
+---
+
+### 🌳 Widget Tree Hierarchy
+
+Scaffold  
+ ┣ AppBar  
+ ┗ Body  
+    ┗ Center  
+       ┗ Column  
+          ┣ Text  
+          ┣ Container  
+          ┗ ElevatedButton  
+
+---
+
+### 🔄 Reactive UI Model
+Flutter uses a reactive UI approach. When the state changes using setState(), Flutter automatically rebuilds only the affected widgets instead of the whole screen. This makes UI updates fast and efficient.
+
+In this demo:
+- Initial UI shows default text and color
+- Clicking the button updates the state
+- Text and container color change instantly
+- Only the required widgets are rebuilt
+
+---
+
+### 🧠 Learning Outcome
+Through this task, I understood how Flutter builds UI using a widget tree and how state changes trigger automatic UI updates. This helped me clearly understand Flutter’s reactive design pattern and efficient rendering system.

--- a/craftconnect/lib/main.dart
+++ b/craftconnect/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:firebase_core/firebase_core.dart';
 
 import 'firebase_options.dart';
 import 'screens/login_screen.dart';
+import 'screens/widget_tree_demo.dart';
+
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,7 +25,7 @@ class CraftConnectApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.teal,
       ),
-      home: const LoginScreen(), // ✅ START FROM LOGIN
+      home: const WidgetTreeDemo(),
     );
   }
 }

--- a/craftconnect/lib/screens/widget_tree_demo.dart
+++ b/craftconnect/lib/screens/widget_tree_demo.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+class WidgetTreeDemo extends StatefulWidget {
+  const WidgetTreeDemo({super.key});
+
+  @override
+  State<WidgetTreeDemo> createState() => _WidgetTreeDemoState();
+}
+
+class _WidgetTreeDemoState extends State<WidgetTreeDemo> {
+  bool isActive = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Widget Tree Demo"),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              isActive ? "State Changed!" : "Initial State",
+              style: const TextStyle(fontSize: 22),
+            ),
+            const SizedBox(height: 20),
+            Container(
+              padding: const EdgeInsets.all(20),
+              color: isActive ? Colors.green : Colors.blue,
+              child: const Text(
+                "This is a Container Widget",
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                setState(() {
+                  isActive = !isActive;
+                });
+              },
+              child: const Text("Change State"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add widget tree demo screen demonstrating reactive UI model

- Implement stateful widget with state management using setState()

- Update app entry point to launch demo instead of login

- Document widget hierarchy and reactive UI concepts in README


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["main.dart<br/>App Entry Point"] -->|imports| B["WidgetTreeDemo<br/>Stateful Widget"]
  B -->|renders| C["Scaffold<br/>with AppBar"]
  C -->|contains| D["Column Layout<br/>with Widgets"]
  D -->|includes| E["Text & Container<br/>with State Binding"]
  E -->|updates via| F["setState() Call<br/>on Button Press"]
  F -->|triggers| G["UI Rebuild<br/>Reactive Update"]
  H["README.md<br/>Documentation"] -->|explains| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.dart</strong><dd><code>Update app entry point to widget tree demo</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

craftconnect/lib/main.dart

<ul><li>Import new <code>WidgetTreeDemo</code> screen<br> <li> Change home route from <code>LoginScreen</code> to <code>WidgetTreeDemo</code><br> <li> Temporarily redirect app entry point for demo purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/16/files#diff-1ad3df5786a4da1b145cc09461ce3c9b38ba14d5f757fda367af0a28967f3c96">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>widget_tree_demo.dart</strong><dd><code>Create widget tree demo with reactive state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

craftconnect/lib/screens/widget_tree_demo.dart

<ul><li>Create new stateful widget <code>WidgetTreeDemo</code> demonstrating reactive UI<br> <li> Implement state management with <code>isActive</code> boolean flag<br> <li> Build widget tree with Scaffold, AppBar, Column, Container, and <br>ElevatedButton<br> <li> Add setState() callback to toggle state and trigger UI rebuild<br> <li> Demonstrate conditional rendering based on state changes</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/16/files#diff-96513fd8ee79882dd8e61735b03466ea7a3335d165b1dd5dc3ecca4a19c15ced">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document widget tree and reactive UI concepts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add Sprint #2 section documenting widget tree and reactive UI concepts<br> <li> Include visual widget hierarchy diagram showing Scaffold structure<br> <li> Explain reactive UI model and how setState() triggers efficient <br>rebuilds<br> <li> Document learning outcomes from the widget tree implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/16/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+36/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

