### PR TITLE
[Sprint-2] Reusable Custom Widgets – Asgardians

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,38 @@ A global theme was applied to the app using ThemeData to ensure consistent color
 - ElevatedButtonTheme for consistent buttons
 - Shared background color for all screens
 
-### Screenshots
-- Home screen with theme
-- Scrollable view with theme
-- Buttons and text styles consistency
-
 ### Reflection
 Using a global theme makes the app look professional and consistent. It also reduces repeated styling code and makes future UI updates easier. The main challenge was replacing hardcoded styles with theme-based styles.
+
+
+# Reusable Custom Widgets
+
+## Description
+
+This task demonstrates how reusable custom widgets can be created in Flutter to reduce code duplication and maintain consistent UI design. Common UI elements were refactored into reusable widgets and used across multiple screens to make the app modular and scalable.
+
+## Custom Widgets Created
+
+The following reusable widgets were created:
+
+CustomButton
+A reusable button widget used for navigation and actions across different screens.
+
+InfoCard
+A reusable card widget used to display structured information such as title, subtitle, and icon.
+
+## Reuse Implementation
+
+The same CustomButton widget is used in both Home Screen and Second Screen with different actions.
+The InfoCard widget is reused multiple times on the Home Screen with different data.
+This approach keeps the UI consistent and reduces repeated code.
+
+### Learning Outcome
+
+I learned how to break large UI code into smaller reusable components, making the codebase cleaner, easier to maintain, and faster to scale for team-based development.
+
+
+
 
 
 

--- a/craftconnect/lib/main.dart
+++ b/craftconnect/lib/main.dart
@@ -59,8 +59,7 @@ class CraftConnectApp extends StatelessWidget {
         ),
       ),
 
-      // ✅ Default screen for Sprint-2 Assets Assignment
-      home: const AssetDemoScreen(),
+      home: const HomeScreen(),
 
       // App routes
       routes: {

--- a/craftconnect/lib/screens/home_screen.dart
+++ b/craftconnect/lib/screens/home_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../widgets/custom_button.dart';
+import '../widgets/info_card.dart'; // ✅ ADDED
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -7,12 +9,31 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Home Screen')),
-      body: Center(
-        child: ElevatedButton(
-          onPressed: () {
-            Navigator.pushNamed(context, '/second');
-          },
-          child: const Text('Go to Second Screen'),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            // ✅ ADDED: Reusable InfoCard widgets
+            const InfoCard(
+              title: 'Products',
+              subtitle: 'View all products',
+              icon: Icons.shopping_bag,
+            ),
+
+            const InfoCard(
+              title: 'Profile',
+              subtitle: 'Manage your account',
+              icon: Icons.person,
+            ),
+
+            const SizedBox(height: 30),
+            CustomButton(
+              text: 'Go to Second Screen',
+              onPressed: () {
+                Navigator.pushNamed(context, '/second');
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/craftconnect/lib/screens/second_screen.dart
+++ b/craftconnect/lib/screens/second_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../widgets/custom_button.dart';
+
 
 class SecondScreen extends StatelessWidget {
   const SecondScreen({super.key});
@@ -16,12 +18,13 @@ class SecondScreen extends StatelessWidget {
           children: [
             Text(message ?? 'No data received'),
             const SizedBox(height: 20),
-            ElevatedButton(
+            CustomButton(
+              text: 'Go Back',
               onPressed: () {
                 Navigator.pop(context);
               },
-              child: const Text('Back to Home'),
             ),
+
           ],
         ),
       ),

--- a/craftconnect/lib/widgets/custom_button.dart
+++ b/craftconnect/lib/widgets/custom_button.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class CustomButton extends StatelessWidget {
+  final String text;
+  final VoidCallback onPressed;
+
+  const CustomButton({
+    super.key,
+    required this.text,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        child: Text(text),
+      ),
+    );
+  }
+}

--- a/craftconnect/lib/widgets/info_card.dart
+++ b/craftconnect/lib/widgets/info_card.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class InfoCard extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+
+  const InfoCard({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: Icon(icon, color: Colors.teal),
+        title: Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+        subtitle: Text(subtitle),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Created reusable custom widgets (`CustomButton`, `InfoCard`) for modular UI

- Refactored screens to use custom widgets reducing code duplication

- Updated home screen with info cards and improved layout structure

- Changed default app home from `AssetDemoScreen` to `HomeScreen`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Custom Widgets<br/>CustomButton<br/>InfoCard"] -->|"Used in"| B["HomeScreen"]
  A -->|"Used in"| C["SecondScreen"]
  B -->|"Replaces"| D["ElevatedButton<br/>Manual layouts"]
  C -->|"Replaces"| D
  E["main.dart"] -->|"Sets home to"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>custom_button.dart</strong><dd><code>Create reusable CustomButton widget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

craftconnect/lib/widgets/custom_button.dart

<ul><li>New reusable button widget with customizable text and callback<br> <li> Extends full width with <code>SizedBox(width: double.infinity)</code><br> <li> Wraps <code>ElevatedButton</code> for consistent styling across app</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/35/files#diff-23eaf34b8522b55c0c299abae0b4f3595f1005b0ce36e4a00c02fd3dc973995a">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>info_card.dart</strong><dd><code>Create reusable InfoCard widget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

craftconnect/lib/widgets/info_card.dart

<ul><li>New reusable card widget displaying title, subtitle, and icon<br> <li> Uses <code>Card</code> and <code>ListTile</code> for structured information display<br> <li> Styled with teal icon color and bold title text</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/35/files#diff-45b5bdf00fbf2fd088522640b7a8f03eaeb4efd9d5ab6ae6de75ad84d10044aa">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>home_screen.dart</strong><dd><code>Refactor HomeScreen to use custom widgets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

craftconnect/lib/screens/home_screen.dart

<ul><li>Imported <code>CustomButton</code> and <code>InfoCard</code> widgets<br> <li> Replaced centered button with padded column layout<br> <li> Added two <code>InfoCard</code> instances for Products and Profile sections<br> <li> Integrated <code>CustomButton</code> for navigation with improved spacing</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/35/files#diff-0b10705ff8b450aac725c816542ea65b4156337fdbdf7a7132c5d85ea6a4359b">+27/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>second_screen.dart</strong><dd><code>Update SecondScreen to use CustomButton</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

craftconnect/lib/screens/second_screen.dart

<ul><li>Imported <code>CustomButton</code> widget<br> <li> Replaced <code>ElevatedButton</code> with <code>CustomButton</code> for back navigation<br> <li> Simplified button implementation using reusable component</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/35/files#diff-2a4b194ff7bea9863488e6b371d4327f46cf86652d4e794e721f2022478a7daa">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.dart</strong><dd><code>Update app home screen to HomeScreen</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

craftconnect/lib/main.dart

<ul><li>Changed default home screen from <code>AssetDemoScreen</code> to <code>HomeScreen</code><br> <li> Removed Sprint-2 Assets Assignment comment</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/35/files#diff-1ad3df5786a4da1b145cc09461ce3c9b38ba14d5f757fda367af0a28967f3c96">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document reusable custom widgets implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Removed outdated Screenshots section<br> <li> Added new "Reusable Custom Widgets" section documenting the feature<br> <li> Documented <code>CustomButton</code> and <code>InfoCard</code> widgets with descriptions<br> <li> Explained reuse implementation across screens<br> <li> Added learning outcome about modular component design</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S86-0126-Asgardians-Building-Smart-Mobile-Experiences-With-Flutter-And-Firebase-CraftConnect/pull/35/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+30/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

